### PR TITLE
add support for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,9 @@
     "timeline",
     "jQuery"
   ],
+  "dependencies": {
+    "jquery": "*"
+  },
   "authors": [
     "Daniele Petrarolo"
   ],

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "flaTimeline.js",
+  "version": "1.1.1",
+  "description": "flaTimeline.js",
+  "main": [
+    "assets/css/jquery.flatimeline.css",
+    "assets/js/jquery.flatimeline.js"
+  ],
+  "keywords": [
+    "flaTimeline",
+    "flat",
+    "timeline",
+    "jQuery"
+  ],
+  "authors": [
+    "Daniele Petrarolo"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*"
+  ]
+}


### PR DESCRIPTION
This is a great plugin. Would you consider making it available via bower?

You should be able to merge this pull request, then:

```
git tag -a 1.1.1
bower register flaTimeline.js git://github.com/DanielePetrarolo/flaTimeline.js.git
```

You can install bower via `sudo npm install -g bower`.
